### PR TITLE
Upgrade to Terraform 0.12

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,51 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ else }}
+{{ range .Unreleased.Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ if .CommitGroups -}}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ else }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,10 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/HENNGE/terraform-aws-autoscaling-mixed-instances
+options:
+  header:
+    pattern: "^(.*)$"
+    pattern_maps:
+      - Subject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.3
+  rev: v1.20.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v1.2.3
+  rev: v2.4.0
   hooks:
     - id: check-merge-conflict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+
+
+<a name="v1.0.0"></a>
+## v1.0.0 - 2019-03-18
+
+- Update Readme
+- Initial conversion ([#1](https://github.com/HENNGE/terraform-aws-autoscaling-mixed-instances/issues/1))
+- Merge pull request [#1](https://github.com/HENNGE/terraform-aws-autoscaling-mixed-instances/issues/1) from terraform-aws-modules/master
+
+
+[Unreleased]: https://github.com/HENNGE/terraform-aws-autoscaling-mixed-instances/compare/v1.0.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: changelog release
+
+changelog:
+	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+
+release:
+	semtag final -s minor

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ These types of resources are supported:
 
 This module will require more than 1 instance type. Suitable to back ECS Cluster.
 
+## Terraform versions
+
+Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+
+Terraform 0.11. Pin module version to `~> v1.0`. Submit pull-requests to `terraform011` branch.
+
+## Amazon Documentations
+* [Autoscaling Group with Multiple Instance Types and Purchase Options](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)
+* [Autoscaling Group Instance Weighting](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-weighting.html)
+
 ## Usage
 
 ```hcl
@@ -76,7 +86,28 @@ module "asg" {
     extra_tag2 = "extra_value2"
   }
   
-  instance_types = ["t2.micro", "t3.micro", "t2.small", "t3.small", "t2.medium"]
+  instance_types = [
+    {
+      instance_type = "t2.micro",
+      weighted_capacity = 1,
+    },
+    {
+      instance_type = "t3.micro",
+      weighted_capacity = 1,
+    },
+    {
+      instance_type = "t2.small",
+      weighted_capacity = 2,
+    },
+    {
+      instance_type = "t3.small",
+      weighted_capacity = 2,
+    },
+    {
+      instance_type = "t2.medium",
+      weighted_capacity = 4,
+    },
+  ]
 
   on_demand_base_capacity                  = 0
   on_demand_percentage_above_base_capacity = 100
@@ -129,18 +160,18 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | asg\_name | Creates a unique name for autoscaling group beginning with the specified prefix | string | `""` | no |
-| associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | string | `"false"` | no |
-| block\_device\_mappings | Mappings of block devices, see https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices | list | `<list>` | no |
-| create\_asg | Whether to create autoscaling group | string | `"true"` | no |
-| create\_asg\_with\_initial\_lifecycle\_hook | Create an ASG with initial lifecycle hook | string | `"false"` | no |
-| create\_lt | Whether to create launch template | string | `"true"` | no |
-| default\_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | string | `"300"` | no |
-| desired\_capacity | The number of Amazon EC2 instances that should be running in the group | string | n/a | yes |
+| associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | bool | `"false"` | no |
+| block\_device\_mappings | Mappings of block devices, see https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices | list(any) | `[ {} ]` | no |
+| create\_asg | Whether to create autoscaling group | bool | `"true"` | no |
+| create\_asg\_with\_initial\_lifecycle\_hook | Create an ASG with initial lifecycle hook | bool | `"false"` | no |
+| create\_lt | Whether to create launch template | bool | `"true"` | no |
+| default\_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | number | `"300"` | no |
+| desired\_capacity | The number of Amazon EC2 instances that should be running in the group | number | n/a | yes |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | string | `"false"` | no |
-| enable\_monitoring | Enables/disables detailed monitoring. This is enabled by default. | string | `"true"` | no |
-| enabled\_metrics | A list of metrics to collect. The allowed values are GroupMinSize, GroupMaxSize, GroupDesiredCapacity, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupTerminatingInstances, GroupTotalInstances | list | `<list>` | no |
-| force\_delete | Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling | string | `"false"` | no |
-| health\_check\_grace\_period | Time (in seconds) after instance comes into service before checking health | string | `"300"` | no |
+| enable\_monitoring | Enables/disables detailed monitoring. This is enabled by default. | bool | `"true"` | no |
+| enabled\_metrics | A list of metrics to collect. The allowed values are GroupMinSize, GroupMaxSize, GroupDesiredCapacity, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupTerminatingInstances, GroupTotalInstances | list(string) | `[ "GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances" ]` | no |
+| force\_delete | Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling | bool | `"false"` | no |
+| health\_check\_grace\_period | Time (in seconds) after instance comes into service before checking health | number | `"300"` | no |
 | health\_check\_type | Controls how health checking is done. Values are - EC2 and ELB | string | n/a | yes |
 | iam\_instance\_profile | The IAM instance profile to associate with launched instances | string | `""` | no |
 | image\_id | The EC2 image ID to launch | string | `""` | no |
@@ -151,49 +182,54 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | initial\_lifecycle\_hook\_notification\_metadata | Contains additional information that you want to include any time Auto Scaling sends a message to the notification target | string | `""` | no |
 | initial\_lifecycle\_hook\_notification\_target\_arn | The ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic | string | `""` | no |
 | initial\_lifecycle\_hook\_role\_arn | The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target | string | `""` | no |
-| instance\_types | The size of instance to launch, minimum 2 types must be specified. | list | `<list>` | no |
+| instance\_types | Instance types to launch, minimum 2 types must be specified. List of Map of 'instance_type'(required) and 'weighted_capacity'(optional). | list(map(string)) | `[ {} ]` | no |
 | key\_name | The key name that should be used for the instance | string | `""` | no |
 | launch\_template | The name of the launch template to use (if it is created outside of this module) | string | `""` | no |
-| load\_balancers | A list of elastic load balancer names to add to the autoscaling group names | list | `<list>` | no |
+| load\_balancers | A list of elastic load balancer names to add to the autoscaling group names | list(string) | `[]` | no |
 | lt\_name | Creates a unique name for launch template beginning with the specified prefix | string | `""` | no |
-| max\_size | The maximum size of the auto scale group | string | n/a | yes |
+| max\_size | The maximum size of the auto scale group | number | n/a | yes |
 | metrics\_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | string | `"1Minute"` | no |
-| min\_elb\_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | string | `"0"` | no |
-| min\_size | The minimum size of the auto scale group | string | n/a | yes |
+| min\_elb\_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | number | `"0"` | no |
+| min\_size | The minimum size of the auto scale group | number | n/a | yes |
 | name | Creates a unique name beginning with the specified prefix | string | n/a | yes |
-| on\_demand\_base\_capacity | Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances | string | `"0"` | no |
-| on\_demand\_percentage\_above\_base\_capacity | Percentage split between on-demand and Spot instances above the base on-demand capacity. | string | `"100"` | no |
+| on\_demand\_base\_capacity | Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances | number | `"0"` | no |
+| on\_demand\_percentage\_above\_base\_capacity | Percentage split between on-demand and Spot instances above the base on-demand capacity. | number | `"100"` | no |
 | placement\_group | The name of the placement group into which you'll launch your instances, if any | string | `""` | no |
 | placement\_tenancy | The tenancy of the instance. Valid values are 'default' or 'dedicated' | string | `"default"` | no |
-| protect\_from\_scale\_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | string | `"false"` | no |
-| recreate\_asg\_when\_lt\_changes | Whether to recreate an autoscaling group when launch template changes | string | `"false"` | no |
-| security\_groups | A list of security group IDs to assign to the launch template | list | `<list>` | no |
+| protect\_from\_scale\_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | bool | `"false"` | no |
+| recreate\_asg\_when\_lt\_changes | Whether to recreate an autoscaling group when launch template changes | bool | `"false"` | no |
+| security\_groups | A list of security group IDs to assign to the launch template | list(string) | `[]` | no |
 | service\_linked\_role\_arn | The ARN of the service-linked role that the ASG will use to call other AWS services | string | `""` | no |
-| spot\_instance\_pools | Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Diversifies your Spot capacity across multiple instance types to find the best pricing. | string | `"1"` | no |
+| spot\_allocation\_strategy | How to allocate capacity across the Spot pools. Valid values: 'lowest-price', 'capacity-optimized'. | string | `"capacity-optimized"` | no |
+| spot\_instance\_pools | Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Diversifies your Spot capacity across multiple instance types to find the best pricing. | number | `"2"` | no |
 | spot\_price | The price to use for reserving spot instances | string | `""` | no |
-| suspended\_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | list | `<list>` | no |
-| tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | list | `<list>` | no |
-| tags\_as\_map | A map of tags and values in the same format as other resources accept. This will be converted into the non-standard format that the aws_autoscaling_group requires. | map | `<map>` | no |
-| target\_group\_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
-| termination\_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default | list | `<list>` | no |
+| suspended\_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | list(string) | `[]` | no |
+| tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | list(map(string)) | `[]` | no |
+| tags\_as\_map | A map of tags and values in the same format as other resources accept. This will be converted into the non-standard format that the aws_autoscaling_group requires. | map(string) | `{}` | no |
+| target\_group\_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list(string) | `[]` | no |
+| termination\_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default | list(string) | `[ "Default" ]` | no |
 | user\_data | The user data to provide when launching the instance | string | `" "` | no |
-| vpc\_zone\_identifier | A list of subnet IDs to launch resources in | list | n/a | yes |
+| vpc\_zone\_identifier | A list of subnet IDs to launch resources in | list(string) | n/a | yes |
 | wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | string | `"10m"` | no |
-| wait\_for\_elb\_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over min_elb_capacity behavior. | string | `"false"` | no |
+| wait\_for\_elb\_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over min_elb_capacity behavior. | number | `"null"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | this\_autoscaling\_group\_arn | The ARN for this AutoScaling Group |
+| this\_autoscaling\_group\_availability\_zones | The availability zones of the autoscale group |
 | this\_autoscaling\_group\_default\_cooldown | Time between a scaling activity and the succeeding scaling activity |
 | this\_autoscaling\_group\_desired\_capacity | The number of Amazon EC2 instances that should be running in the group |
 | this\_autoscaling\_group\_health\_check\_grace\_period | Time after instance comes into service before checking health |
 | this\_autoscaling\_group\_health\_check\_type | EC2 or ELB. Controls how health checking is done |
 | this\_autoscaling\_group\_id | The autoscaling group id |
+| this\_autoscaling\_group\_load\_balancers | The load balancer names associated with the autoscaling group |
 | this\_autoscaling\_group\_max\_size | The maximum size of the autoscale group |
 | this\_autoscaling\_group\_min\_size | The minimum size of the autoscale group |
 | this\_autoscaling\_group\_name | The autoscaling group name |
+| this\_autoscaling\_group\_target\_group\_arns | List of Target Group ARNs that apply to this AutoScaling Group |
+| this\_autoscaling\_group\_vpc\_zone\_identifier | The VPC zone identifier |
 | this\_launch\_template\_id | The ID of the launch template |
 | this\_launch\_template\_name | The name of the launch template |
 

--- a/examples/asg_ec2/README.md
+++ b/examples/asg_ec2/README.md
@@ -21,7 +21,11 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
+| this\_autoscaling\_group\_availability\_zones | The availability zones of the autoscale group |
 | this\_autoscaling\_group\_id | The autoscaling group id |
+| this\_autoscaling\_group\_load\_balancers | The load balancer names associated with the autoscaling group |
+| this\_autoscaling\_group\_target\_group\_arns | List of Target Group ARNs that apply to this AutoScaling Group |
+| this\_autoscaling\_group\_vpc\_zone\_identifier | The VPC zone identifier |
 | this\_launch\_template\_id | The ID of the launch template |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_ec2/outputs.tf
+++ b/examples/asg_ec2/outputs.tf
@@ -1,9 +1,29 @@
 output "this_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.example.this_launch_template_id}"
+  value       = module.example.this_launch_template_id
 }
 
 output "this_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${module.example.this_autoscaling_group_id}"
+  value       = module.example.this_autoscaling_group_id
+}
+
+output "this_autoscaling_group_availability_zones" {
+  description = "The availability zones of the autoscale group"
+  value       = module.example.this_autoscaling_group_availability_zones
+}
+
+output "this_autoscaling_group_vpc_zone_identifier" {
+  description = "The VPC zone identifier"
+  value       = module.example.this_autoscaling_group_vpc_zone_identifier
+}
+
+output "this_autoscaling_group_load_balancers" {
+  description = "The load balancer names associated with the autoscaling group"
+  value       = module.example.this_autoscaling_group_load_balancers
+}
+
+output "this_autoscaling_group_target_group_arns" {
+  description = "List of Target Group ARNs that apply to this AutoScaling Group"
+  value       = module.example.this_autoscaling_group_target_group_arns
 }

--- a/examples/asg_ec2_external_launch_template/main.tf
+++ b/examples/asg_ec2_external_launch_template/main.tf
@@ -17,11 +17,12 @@ data "aws_vpc" "default" {
 }
 
 data "aws_subnet_ids" "all" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners      = ["137112412989"] # Amazon
 
   filter {
     name = "name"
@@ -46,7 +47,7 @@ data "aws_ami" "amazon_linux" {
 #######################
 resource "aws_launch_template" "this" {
   name_prefix = "my-launch-template-"
-  image_id    = "${data.aws_ami.amazon_linux.id}"
+  image_id    = data.aws_ami.amazon_linux.id
 
   lifecycle {
     create_before_destroy = true
@@ -59,7 +60,7 @@ module "example" {
   name = "example-with-ec2-external-lt"
 
   # Use of existing launch template (created outside of this module)
-  launch_template = "${aws_launch_template.this.name}"
+  launch_template = aws_launch_template.this.name
 
   create_lt = false
 
@@ -67,7 +68,7 @@ module "example" {
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1
@@ -92,5 +93,8 @@ module "example" {
     extra_tag2 = "extra_value2"
   }
 
-  instance_types = ["t2.micro", "t3.micro"]
+  instance_types = [
+    { instance_type = "t2.micro" },
+    { instance_type = "t3.micro" }
+  ]
 }

--- a/examples/asg_ec2_external_launch_template/outputs.tf
+++ b/examples/asg_ec2_external_launch_template/outputs.tf
@@ -1,9 +1,9 @@
 output "this_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.example.this_launch_template_id}"
+  value       = module.example.this_launch_template_id
 }
 
 output "this_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${module.example.this_autoscaling_group_id}"
+  value       = module.example.this_autoscaling_group_id
 }

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -10,16 +10,17 @@ data "aws_vpc" "default" {
 }
 
 data "aws_subnet_ids" "all" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
 data "aws_security_group" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
   name   = "default"
 }
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners      = ["137112412989"] # Amazon
 
   filter {
     name = "name"
@@ -52,10 +53,13 @@ module "example_asg" {
   # create_lt = false # disables creation of launch template
   lt_name = "example-lt"
 
-  image_id        = "${data.aws_ami.amazon_linux.id}"
-  instance_types  = ["t2.micro", "t3.micro"]
-  security_groups = ["${data.aws_security_group.default.id}"]
-  load_balancers  = ["${module.elb.this_elb_id}"]
+  image_id = data.aws_ami.amazon_linux.id
+  instance_types = [
+    { instance_type = "t2.micro" },
+    { instance_type = "t3.micro" }
+  ]
+  security_groups = [data.aws_security_group.default.id]
+  load_balancers  = [module.elb.this_elb_id]
 
   block_device_mappings = [
     {
@@ -84,7 +88,7 @@ module "example_asg" {
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1
@@ -113,8 +117,8 @@ module "elb" {
 
   name = "elb-example"
 
-  subnets         = ["${data.aws_subnet_ids.all.ids}"]
-  security_groups = ["${data.aws_security_group.default.id}"]
+  subnets         = data.aws_subnet_ids.all.ids
+  security_groups = [data.aws_security_group.default.id]
   internal        = false
 
   listener = [
@@ -126,15 +130,13 @@ module "elb" {
     },
   ]
 
-  health_check = [
-    {
-      target              = "HTTP:80/"
-      interval            = 30
-      healthy_threshold   = 2
-      unhealthy_threshold = 2
-      timeout             = 5
-    },
-  ]
+  health_check = {
+    target              = "HTTP:80/"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+  }
 
   tags = {
     Owner       = "user"

--- a/examples/asg_elb/outputs.tf
+++ b/examples/asg_elb/outputs.tf
@@ -1,17 +1,17 @@
-# Launch configuration
+# Launch template
 output "this_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.example_asg.this_launch_template_id}"
+  value       = module.example_asg.this_launch_template_id
 }
 
 # Autoscaling group
 output "this_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${module.example_asg.this_autoscaling_group_id}"
+  value       = module.example_asg.this_autoscaling_group_id
 }
 
 # ELB DNS name
 output "this_elb_dns_name" {
   description = "DNS Name of the ELB"
-  value       = "${module.elb.this_elb_dns_name}"
+  value       = module.elb.this_elb_dns_name
 }

--- a/examples/asg_inital_lifecycle_hook/main.tf
+++ b/examples/asg_inital_lifecycle_hook/main.tf
@@ -17,16 +17,17 @@ data "aws_vpc" "default" {
 }
 
 data "aws_subnet_ids" "all" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
 data "aws_security_group" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
   name   = "default"
 }
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners      = ["137112412989"] # Amazon
 
   filter {
     name = "name"
@@ -72,9 +73,12 @@ EOF
   # create_lt = false # disables creation of launch template
   lt_name = "example-lt"
 
-  image_id                     = "${data.aws_ami.amazon_linux.id}"
-  instance_types               = ["t2.micro", "t3.micro"]
-  security_groups              = ["${data.aws_security_group.default.id}"]
+  image_id = data.aws_ami.amazon_linux.id
+  instance_types = [
+    { instance_type = "t2.micro" },
+    { instance_type = "t3.micro" }
+  ]
+  security_groups              = [data.aws_security_group.default.id]
   associate_public_ip_address  = true
   recreate_asg_when_lt_changes = true
 
@@ -105,7 +109,7 @@ EOF
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1

--- a/examples/asg_inital_lifecycle_hook/outputs.tf
+++ b/examples/asg_inital_lifecycle_hook/outputs.tf
@@ -1,9 +1,9 @@
 output "this_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.example.this_launch_template_id}"
+  value       = module.example.this_launch_template_id
 }
 
 output "this_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${module.example.this_autoscaling_group_id}"
+  value       = module.example.this_autoscaling_group_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,22 +1,13 @@
 locals {
-  tags_asg_format = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
-  instance_types  = ["${data.null_data_source.instance_types.*.outputs}"]
+  tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 }
 
 resource "null_resource" "tags_as_list_of_maps" {
-  count = "${length(keys(var.tags_as_map))}"
+  count = length(keys(var.tags_as_map))
 
-  triggers = "${map(
-    "key", "${element(keys(var.tags_as_map), count.index)}",
-    "value", "${element(values(var.tags_as_map), count.index)}",
-    "propagate_at_launch", "true"
-  )}"
-}
-
-data "null_data_source" "instance_types" {
-  count = "${length(var.instance_types)}"
-
-  inputs = "${map(
-    "instance_type", trimspace(element(var.instance_types, count.index))
-  )}"
+  triggers = {
+    key                 = keys(var.tags_as_map)[count.index]
+    value               = values(var.tags_as_map)[count.index]
+    propagate_at_launch = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,34 +2,54 @@
 # Launch template
 #######################
 resource "aws_launch_template" "this" {
-  count = "${var.create_lt}"
+  count = var.create_lt ? 1 : 0
 
-  name_prefix           = "${coalesce(var.lt_name, var.name)}-"
-  image_id              = "${var.image_id}"
-  instance_type         = ""
-  key_name              = "${var.key_name}"
-  user_data             = "${base64encode(var.user_data)}"
-  ebs_optimized         = "${var.ebs_optimized}"
-  block_device_mappings = "${var.block_device_mappings}"
+  name_prefix   = "${coalesce(var.lt_name, var.name)}-"
+  image_id      = var.image_id
+  instance_type = ""
+  key_name      = var.key_name
+  user_data     = base64encode(var.user_data)
+  ebs_optimized = var.ebs_optimized
+  dynamic "block_device_mappings" {
+    for_each = var.block_device_mappings
+    content {
+      device_name  = lookup(block_device_mappings.value, "device_name", null)
+      no_device    = lookup(block_device_mappings.value, "no_device", null)
+      virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
+
+      dynamic "ebs" {
+        for_each = lookup(block_device_mappings.value, "ebs", [])
+        content {
+          delete_on_termination = lookup(ebs.value, "delete_on_termination", null)
+          encrypted             = lookup(ebs.value, "encrypted", null)
+          iops                  = lookup(ebs.value, "iops", null)
+          kms_key_id            = lookup(ebs.value, "kms_key_id", null)
+          snapshot_id           = lookup(ebs.value, "snapshot_id", null)
+          volume_size           = lookup(ebs.value, "volume_size", null)
+          volume_type           = lookup(ebs.value, "volume_type", null)
+        }
+      }
+    }
+  }
 
   iam_instance_profile {
-    arn = "${var.iam_instance_profile}"
+    arn = var.iam_instance_profile
   }
 
   network_interfaces {
-    description                 = "${coalesce(var.lt_name, var.name)}"
+    description                 = coalesce(var.lt_name, var.name)
     device_index                = 0
-    associate_public_ip_address = "${var.associate_public_ip_address}"
+    associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
-    security_groups             = ["${var.security_groups}"]
+    security_groups             = var.security_groups
   }
 
   monitoring {
-    enabled = "${var.enable_monitoring}"
+    enabled = var.enable_monitoring
   }
 
   placement {
-    tenancy = "${var.placement_tenancy}"
+    tenancy = var.placement_tenancy
   }
 
   lifecycle {
@@ -41,55 +61,76 @@ resource "aws_launch_template" "this" {
 # Autoscaling group
 ####################
 resource "aws_autoscaling_group" "this" {
-  count = "${var.create_asg && !var.create_asg_with_initial_lifecycle_hook ? 1 : 0}"
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook ? 1 : 0
 
-  name_prefix         = "${join("-", compact(list(coalesce(var.asg_name, var.name), var.recreate_asg_when_lt_changes ? element(concat(random_pet.asg_name.*.id, list("")), 0) : "")))}-"
-  vpc_zone_identifier = ["${var.vpc_zone_identifier}"]
-  max_size            = "${var.max_size}"
-  min_size            = "${var.min_size}"
-  desired_capacity    = "${var.desired_capacity}"
+  name_prefix = "${join(
+    "-",
+    compact(
+      [
+        coalesce(var.asg_name, var.name),
+        var.recreate_asg_when_lt_changes ? element(concat(random_pet.asg_name.*.id, [""]), 0) : "",
+      ],
+    ),
+  )}-"
+  vpc_zone_identifier = var.vpc_zone_identifier
+  max_size            = var.max_size
+  min_size            = var.min_size
+  desired_capacity    = var.desired_capacity
 
-  load_balancers            = ["${var.load_balancers}"]
-  health_check_grace_period = "${var.health_check_grace_period}"
-  health_check_type         = "${var.health_check_type}"
+  load_balancers            = var.load_balancers
+  health_check_grace_period = var.health_check_grace_period
+  health_check_type         = var.health_check_type
 
-  min_elb_capacity          = "${var.min_elb_capacity}"
-  wait_for_elb_capacity     = "${var.wait_for_elb_capacity}"
-  target_group_arns         = ["${var.target_group_arns}"]
-  default_cooldown          = "${var.default_cooldown}"
-  force_delete              = "${var.force_delete}"
-  termination_policies      = "${var.termination_policies}"
-  suspended_processes       = "${var.suspended_processes}"
-  placement_group           = "${var.placement_group}"
-  enabled_metrics           = ["${var.enabled_metrics}"]
-  metrics_granularity       = "${var.metrics_granularity}"
-  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
-  protect_from_scale_in     = "${var.protect_from_scale_in}"
-  service_linked_role_arn   = "${var.service_linked_role_arn}"
+  min_elb_capacity          = var.min_elb_capacity
+  wait_for_elb_capacity     = var.wait_for_elb_capacity
+  target_group_arns         = var.target_group_arns
+  default_cooldown          = var.default_cooldown
+  force_delete              = var.force_delete
+  termination_policies      = var.termination_policies
+  suspended_processes       = var.suspended_processes
+  placement_group           = var.placement_group
+  enabled_metrics           = var.enabled_metrics
+  metrics_granularity       = var.metrics_granularity
+  wait_for_capacity_timeout = var.wait_for_capacity_timeout
+  protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
 
   mixed_instances_policy {
-    "launch_template" {
-      "launch_template_specification" {
-        launch_template_id = "${var.create_lt ? element(concat(aws_launch_template.this.*.id, list("")), 0) : var.launch_template}"
-        version            = "$$Latest"
+    launch_template {
+      launch_template_specification {
+        launch_template_id = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : var.launch_template
+        version            = "$Latest"
       }
 
-      override = ["${local.instance_types}"]
+      dynamic "override" {
+        for_each = var.instance_types
+        content {
+          instance_type     = lookup(override.value, "instance_type", null)
+          weighted_capacity = lookup(override.value, "weighted_capacity", null)
+        }
+      }
     }
 
-    "instances_distribution" {
-      on_demand_base_capacity                  = "${var.on_demand_base_capacity}"
-      on_demand_percentage_above_base_capacity = "${var.on_demand_percentage_above_base_capacity}"
-      spot_instance_pools                      = "${var.spot_instance_pools}"
-      spot_max_price                           = "${var.spot_price}"
+    instances_distribution {
+      on_demand_base_capacity                  = var.on_demand_base_capacity
+      on_demand_percentage_above_base_capacity = var.on_demand_percentage_above_base_capacity
+      spot_allocation_strategy                 = var.spot_allocation_strategy
+      spot_instance_pools                      = var.spot_allocation_strategy == "lowest-price" ? var.spot_instance_pools : null
+      spot_max_price                           = var.spot_price
     }
   }
 
-  tags = ["${concat(
-      list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
-      var.tags,
-      local.tags_asg_format
-   )}"]
+  tags = concat(
+    [
+      {
+        key                 = "Name"
+        value               = var.name
+        propagate_at_launch = true
+      },
+    ],
+    var.tags,
+    local.tags_asg_format,
+  )
 
   lifecycle {
     create_before_destroy = true
@@ -100,65 +141,86 @@ resource "aws_autoscaling_group" "this" {
 # Autoscaling group with initial lifecycle hook
 ################################################
 resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
-  count = "${var.create_asg && var.create_asg_with_initial_lifecycle_hook ? 1 : 0}"
+  count = var.create_asg && var.create_asg_with_initial_lifecycle_hook ? 1 : 0
 
-  name_prefix         = "${join("-", compact(list(coalesce(var.asg_name, var.name), var.recreate_asg_when_lt_changes ? element(concat(random_pet.asg_name.*.id, list("")), 0) : "")))}-"
-  vpc_zone_identifier = ["${var.vpc_zone_identifier}"]
-  max_size            = "${var.max_size}"
-  min_size            = "${var.min_size}"
-  desired_capacity    = "${var.desired_capacity}"
+  name_prefix = "${join(
+    "-",
+    compact(
+      [
+        coalesce(var.asg_name, var.name),
+        var.recreate_asg_when_lt_changes ? element(concat(random_pet.asg_name.*.id, [""]), 0) : "",
+      ],
+    ),
+  )}-"
+  vpc_zone_identifier = var.vpc_zone_identifier
+  max_size            = var.max_size
+  min_size            = var.min_size
+  desired_capacity    = var.desired_capacity
 
-  load_balancers            = ["${var.load_balancers}"]
-  health_check_grace_period = "${var.health_check_grace_period}"
-  health_check_type         = "${var.health_check_type}"
+  load_balancers            = var.load_balancers
+  health_check_grace_period = var.health_check_grace_period
+  health_check_type         = var.health_check_type
 
-  min_elb_capacity          = "${var.min_elb_capacity}"
-  wait_for_elb_capacity     = "${var.wait_for_elb_capacity}"
-  target_group_arns         = ["${var.target_group_arns}"]
-  default_cooldown          = "${var.default_cooldown}"
-  force_delete              = "${var.force_delete}"
-  termination_policies      = "${var.termination_policies}"
-  suspended_processes       = "${var.suspended_processes}"
-  placement_group           = "${var.placement_group}"
-  enabled_metrics           = ["${var.enabled_metrics}"]
-  metrics_granularity       = "${var.metrics_granularity}"
-  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
-  protect_from_scale_in     = "${var.protect_from_scale_in}"
-  service_linked_role_arn   = "${var.service_linked_role_arn}"
+  min_elb_capacity          = var.min_elb_capacity
+  wait_for_elb_capacity     = var.wait_for_elb_capacity
+  target_group_arns         = var.target_group_arns
+  default_cooldown          = var.default_cooldown
+  force_delete              = var.force_delete
+  termination_policies      = var.termination_policies
+  suspended_processes       = var.suspended_processes
+  placement_group           = var.placement_group
+  enabled_metrics           = var.enabled_metrics
+  metrics_granularity       = var.metrics_granularity
+  wait_for_capacity_timeout = var.wait_for_capacity_timeout
+  protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
 
   mixed_instances_policy {
-    "launch_template" {
-      "launch_template_specification" {
-        launch_template_id = "${var.create_lt ? element(concat(aws_launch_template.this.*.id, list("")), 0) : var.launch_template}"
-        version            = "$$Latest"
+    launch_template {
+      launch_template_specification {
+        launch_template_id = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : var.launch_template
+        version            = "$Latest"
       }
 
-      override = ["${local.instance_types}"]
+      dynamic "override" {
+        for_each = var.instance_types
+        content {
+          instance_type     = lookup(override.value, "instance_type", null)
+          weighted_capacity = lookup(override.value, "weighted_capacity", null)
+        }
+      }
     }
 
-    "instances_distribution" {
-      on_demand_base_capacity                  = "${var.on_demand_base_capacity}"
-      on_demand_percentage_above_base_capacity = "${var.on_demand_percentage_above_base_capacity}"
-      spot_instance_pools                      = "${var.spot_instance_pools}"
-      spot_max_price                           = "${var.spot_price}"
+    instances_distribution {
+      on_demand_base_capacity                  = var.on_demand_base_capacity
+      on_demand_percentage_above_base_capacity = var.on_demand_percentage_above_base_capacity
+      spot_allocation_strategy                 = var.spot_allocation_strategy
+      spot_instance_pools                      = var.spot_allocation_strategy == "lowest-price" ? var.spot_instance_pools : null
+      spot_max_price                           = var.spot_price
     }
   }
 
   initial_lifecycle_hook {
-    name                    = "${var.initial_lifecycle_hook_name}"
-    lifecycle_transition    = "${var.initial_lifecycle_hook_lifecycle_transition}"
-    notification_metadata   = "${var.initial_lifecycle_hook_notification_metadata}"
-    heartbeat_timeout       = "${var.initial_lifecycle_hook_heartbeat_timeout}"
-    notification_target_arn = "${var.initial_lifecycle_hook_notification_target_arn}"
-    role_arn                = "${var.initial_lifecycle_hook_role_arn}"
-    default_result          = "${var.initial_lifecycle_hook_default_result}"
+    name                    = var.initial_lifecycle_hook_name
+    lifecycle_transition    = var.initial_lifecycle_hook_lifecycle_transition
+    notification_metadata   = var.initial_lifecycle_hook_notification_metadata
+    heartbeat_timeout       = var.initial_lifecycle_hook_heartbeat_timeout
+    notification_target_arn = var.initial_lifecycle_hook_notification_target_arn
+    role_arn                = var.initial_lifecycle_hook_role_arn
+    default_result          = var.initial_lifecycle_hook_default_result
   }
 
-  tags = ["${concat(
-      list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
-      var.tags,
-      local.tags_asg_format
-   )}"]
+  tags = concat(
+    [
+      {
+        key                 = "Name"
+        value               = var.name
+        propagate_at_launch = true
+      },
+    ],
+    var.tags,
+    local.tags_asg_format,
+  )
 
   lifecycle {
     create_before_destroy = true
@@ -166,13 +228,14 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
 }
 
 resource "random_pet" "asg_name" {
-  count = "${var.recreate_asg_when_lt_changes ? 1 : 0}"
+  count = var.recreate_asg_when_lt_changes ? 1 : 0
 
   separator = "-"
   length    = 2
 
   keepers = {
     # Generate a new pet name each time we switch launch template
-    lt_name = "${var.create_lt ? element(concat(aws_launch_template.this.*.name, list("")), 0) : var.launch_template}"
+    lt_name = var.create_lt ? element(concat(aws_launch_template.this.*.name, [""]), 0) : var.launch_template
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,85 +1,93 @@
 locals {
-  this_launch_template_id   = "${var.launch_template == "" && var.create_lt ? element(concat(aws_launch_template.this.*.id, list("")), 0) : var.launch_template}"
-  this_launch_template_name = "${var.launch_template == "" && var.create_lt ? element(concat(aws_launch_template.this.*.name, list("")), 0) : ""}"
+  this_launch_template_id   = var.launch_template == "" && var.create_lt ? concat(aws_launch_template.this.*.id, list(""))[0] : var.launch_template
+  this_launch_template_name = var.launch_template == "" && var.create_lt ? concat(aws_launch_template.this.*.name, list(""))[0] : ""
 
-  this_autoscaling_group_id                        = "${element(concat(coalescelist(aws_autoscaling_group.this.*.id, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.id), list("")), 0)}"
-  this_autoscaling_group_name                      = "${element(concat(coalescelist(aws_autoscaling_group.this.*.name, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.name), list("")), 0)}"
-  this_autoscaling_group_arn                       = "${element(concat(coalescelist(aws_autoscaling_group.this.*.arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.arn), list("")), 0)}"
-  this_autoscaling_group_min_size                  = "${element(concat(coalescelist(aws_autoscaling_group.this.*.min_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.min_size), list("")), 0)}"
-  this_autoscaling_group_max_size                  = "${element(concat(coalescelist(aws_autoscaling_group.this.*.max_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.max_size), list("")), 0)}"
-  this_autoscaling_group_desired_capacity          = "${element(concat(coalescelist(aws_autoscaling_group.this.*.desired_capacity, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.desired_capacity), list("")), 0)}"
-  this_autoscaling_group_default_cooldown          = "${element(concat(coalescelist(aws_autoscaling_group.this.*.default_cooldown, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.default_cooldown), list("")), 0)}"
-  this_autoscaling_group_health_check_grace_period = "${element(concat(coalescelist(aws_autoscaling_group.this.*.health_check_grace_period, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_grace_period), list("")), 0)}"
-  this_autoscaling_group_health_check_type         = "${element(concat(coalescelist(aws_autoscaling_group.this.*.health_check_type, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_type), list("")), 0)}"
+  this_autoscaling_group_id                        = concat(aws_autoscaling_group.this.*.id, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.id, [""])[0]
+  this_autoscaling_group_name                      = concat(aws_autoscaling_group.this.*.name, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.name, [""])[0]
+  this_autoscaling_group_arn                       = concat(aws_autoscaling_group.this.*.arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.arn, [""])[0]
+  this_autoscaling_group_min_size                  = concat(aws_autoscaling_group.this.*.min_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.min_size, [""])[0]
+  this_autoscaling_group_max_size                  = concat(aws_autoscaling_group.this.*.max_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.max_size, [""])[0]
+  this_autoscaling_group_desired_capacity          = concat(aws_autoscaling_group.this.*.desired_capacity, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.desired_capacity, [""])[0]
+  this_autoscaling_group_default_cooldown          = concat(aws_autoscaling_group.this.*.default_cooldown, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.default_cooldown, [""])[0]
+  this_autoscaling_group_health_check_grace_period = concat(aws_autoscaling_group.this.*.health_check_grace_period, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_grace_period, [""])[0]
+  this_autoscaling_group_health_check_type         = concat(aws_autoscaling_group.this.*.health_check_type, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_type, [""])[0]
+  this_autoscaling_group_availability_zones        = concat(aws_autoscaling_group.this.*.availability_zones, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.availability_zones, [""])[0]
+  this_autoscaling_group_vpc_zone_identifier       = concat(aws_autoscaling_group.this.*.vpc_zone_identifier, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.vpc_zone_identifier, [""])[0]
+  this_autoscaling_group_load_balancers            = concat(aws_autoscaling_group.this.*.load_balancers, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.load_balancers, [""])[0]
+  this_autoscaling_group_target_group_arns         = concat(aws_autoscaling_group.this.*.target_group_arns, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.target_group_arns, [""])[0]
 }
 
 output "this_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${local.this_launch_template_id}"
+  value       = local.this_launch_template_id
 }
 
 output "this_launch_template_name" {
   description = "The name of the launch template"
-  value       = "${local.this_launch_template_name}"
+  value       = local.this_launch_template_name
 }
 
 output "this_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${local.this_autoscaling_group_id}"
+  value       = local.this_autoscaling_group_id
 }
 
 output "this_autoscaling_group_name" {
   description = "The autoscaling group name"
-  value       = "${local.this_autoscaling_group_name}"
+  value       = local.this_autoscaling_group_name
 }
 
 output "this_autoscaling_group_arn" {
   description = "The ARN for this AutoScaling Group"
-  value       = "${local.this_autoscaling_group_arn}"
+  value       = local.this_autoscaling_group_arn
 }
 
 output "this_autoscaling_group_min_size" {
   description = "The minimum size of the autoscale group"
-  value       = "${local.this_autoscaling_group_min_size}"
+  value       = local.this_autoscaling_group_min_size
 }
 
 output "this_autoscaling_group_max_size" {
   description = "The maximum size of the autoscale group"
-  value       = "${local.this_autoscaling_group_max_size}"
+  value       = local.this_autoscaling_group_max_size
 }
 
 output "this_autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = "${local.this_autoscaling_group_desired_capacity}"
+  value       = local.this_autoscaling_group_desired_capacity
 }
 
 output "this_autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = "${local.this_autoscaling_group_default_cooldown}"
+  value       = local.this_autoscaling_group_default_cooldown
 }
 
 output "this_autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = "${local.this_autoscaling_group_health_check_grace_period}"
+  value       = local.this_autoscaling_group_health_check_grace_period
 }
 
 output "this_autoscaling_group_health_check_type" {
   description = "EC2 or ELB. Controls how health checking is done"
-  value       = "${local.this_autoscaling_group_health_check_type}"
+  value       = local.this_autoscaling_group_health_check_type
 }
 
-//output "this_autoscaling_group_vpc_zone_identifier" {
-//  description = "The VPC zone identifier"
-//  value       = "${element(concat(aws_autoscaling_group.this.vpc_zone_identifier, list("")), 0)}"
-//}
-//
-//output "this_autoscaling_group_load_balancers" {
-//  description = "The load balancer names associated with the autoscaling group"
-//  value       = "${aws_autoscaling_group.this.load_balancers}"
-//}
-//
-//output "this_autoscaling_group_target_group_arns" {
-//  description = "List of Target Group ARNs that apply to this AutoScaling Group"
-//  value       = "${aws_autoscaling_group.this.target_group_arns}"
-//}
+output "this_autoscaling_group_availability_zones" {
+  description = "The availability zones of the autoscale group"
+  value       = local.this_autoscaling_group_availability_zones
+}
 
+output "this_autoscaling_group_vpc_zone_identifier" {
+  description = "The VPC zone identifier"
+  value       = local.this_autoscaling_group_vpc_zone_identifier
+}
+
+output "this_autoscaling_group_load_balancers" {
+  description = "The load balancer names associated with the autoscaling group"
+  value       = local.this_autoscaling_group_load_balancers
+}
+
+output "this_autoscaling_group_target_group_arns" {
+  description = "List of Target Group ARNs that apply to this AutoScaling Group"
+  value       = local.this_autoscaling_group_target_group_arns
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,117 +1,138 @@
 variable "create_lt" {
   description = "Whether to create launch template"
+  type        = bool
   default     = true
 }
 
 variable "create_asg" {
   description = "Whether to create autoscaling group"
+  type        = bool
   default     = true
 }
 
 variable "create_asg_with_initial_lifecycle_hook" {
   description = "Create an ASG with initial lifecycle hook"
+  type        = bool
   default     = false
 }
 
 variable "initial_lifecycle_hook_name" {
   description = "The name of initial lifecycle hook"
+  type        = string
   default     = ""
 }
 
 variable "initial_lifecycle_hook_lifecycle_transition" {
   description = "The instance state to which you want to attach the initial lifecycle hook"
+  type        = string
   default     = ""
 }
 
 variable "initial_lifecycle_hook_default_result" {
   description = "Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. The value for this parameter can be either CONTINUE or ABANDON"
+  type        = string
   default     = "ABANDON"
 }
 
 variable "initial_lifecycle_hook_notification_metadata" {
   description = "Contains additional information that you want to include any time Auto Scaling sends a message to the notification target"
+  type        = string
   default     = ""
 }
 
 variable "initial_lifecycle_hook_heartbeat_timeout" {
   description = "Defines the amount of time, in seconds, that can elapse before the lifecycle hook times out. When the lifecycle hook times out, Auto Scaling performs the action defined in the DefaultResult parameter"
+  type        = string
   default     = "60"
 }
 
 variable "initial_lifecycle_hook_notification_target_arn" {
   description = "The ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic"
+  type        = string
   default     = ""
 }
 
 variable "initial_lifecycle_hook_role_arn" {
   description = "The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target"
+  type        = string
   default     = ""
 }
 
 variable "recreate_asg_when_lt_changes" {
   description = "Whether to recreate an autoscaling group when launch template changes"
+  type        = bool
   default     = false
 }
 
 variable "name" {
   description = "Creates a unique name beginning with the specified prefix"
+  type        = string
 }
 
 variable "lt_name" {
   description = "Creates a unique name for launch template beginning with the specified prefix"
+  type        = string
   default     = ""
 }
 
 variable "asg_name" {
   description = "Creates a unique name for autoscaling group beginning with the specified prefix"
+  type        = string
   default     = ""
 }
 
 variable "launch_template" {
   description = "The name of the launch template to use (if it is created outside of this module)"
+  type        = string
   default     = ""
 }
 
 # Launch template
 variable "image_id" {
   description = "The EC2 image ID to launch"
+  type        = string
   default     = ""
 }
 
 variable "instance_types" {
-  description = "The size of instance to launch, minimum 2 types must be specified."
-  type        = "list"
-  default     = []
+  description = "Instance types to launch, minimum 2 types must be specified. List of Map of 'instance_type'(required) and 'weighted_capacity'(optional)."
+  type        = list(map(string))
+  default     = [{}]
 }
 
 variable "iam_instance_profile" {
   description = "The IAM instance profile to associate with launched instances"
+  type        = string
   default     = ""
 }
 
 variable "key_name" {
   description = "The key name that should be used for the instance"
+  type        = string
   default     = ""
 }
 
 variable "security_groups" {
   description = "A list of security group IDs to assign to the launch template"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "associate_public_ip_address" {
   description = "Associate a public ip address with an instance in a VPC"
+  type        = bool
   default     = false
 }
 
 variable "user_data" {
   description = "The user data to provide when launching the instance"
+  type        = string
   default     = " "
 }
 
 variable "enable_monitoring" {
   description = "Enables/disables detailed monitoring. This is enabled by default."
+  type        = bool
   default     = true
 }
 
@@ -122,97 +143,111 @@ variable "ebs_optimized" {
 
 variable "block_device_mappings" {
   description = "Mappings of block devices, see https://www.terraform.io/docs/providers/aws/r/launch_template.html#block-devices"
-  type        = "list"
-  default     = []
+  type        = list(any)
+  default     = [{}]
 }
 
 variable "placement_tenancy" {
   description = "The tenancy of the instance. Valid values are 'default' or 'dedicated'"
+  type        = string
   default     = "default"
 }
 
 # Autoscaling group
 variable "max_size" {
   description = "The maximum size of the auto scale group"
+  type        = number
 }
 
 variable "min_size" {
   description = "The minimum size of the auto scale group"
+  type        = number
 }
 
 variable "desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
+  type        = number
 }
 
 variable "vpc_zone_identifier" {
   description = "A list of subnet IDs to launch resources in"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "default_cooldown" {
   description = "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start"
+  type        = number
   default     = 300
 }
 
 variable "health_check_grace_period" {
   description = "Time (in seconds) after instance comes into service before checking health"
+  type        = number
   default     = 300
 }
 
 variable "health_check_type" {
   description = "Controls how health checking is done. Values are - EC2 and ELB"
+  type        = string
 }
 
 variable "force_delete" {
   description = "Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling"
+  type        = bool
   default     = false
 }
 
 variable "load_balancers" {
   description = "A list of elastic load balancer names to add to the autoscaling group names"
+  type        = list(string)
   default     = []
 }
 
 variable "target_group_arns" {
   description = "A list of aws_alb_target_group ARNs, for use with Application Load Balancing"
+  type        = list(string)
   default     = []
 }
 
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default"
-  type        = "list"
+  type        = list(string)
   default     = ["Default"]
 }
 
 variable "suspended_processes" {
   description = "A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly."
+  type        = list(string)
   default     = []
 }
 
 variable "tags" {
   description = "A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch."
+  type        = list(map(string))
   default     = []
 }
 
 variable "tags_as_map" {
   description = "A map of tags and values in the same format as other resources accept. This will be converted into the non-standard format that the aws_autoscaling_group requires."
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
 variable "placement_group" {
   description = "The name of the placement group into which you'll launch your instances, if any"
+  type        = string
   default     = ""
 }
 
 variable "metrics_granularity" {
   description = "The granularity to associate with the metrics to collect. The only valid value is 1Minute"
+  type        = string
   default     = "1Minute"
 }
 
 variable "enabled_metrics" {
   description = "A list of metrics to collect. The allowed values are GroupMinSize, GroupMaxSize, GroupDesiredCapacity, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupTerminatingInstances, GroupTotalInstances"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "GroupMinSize",
@@ -228,45 +263,61 @@ variable "enabled_metrics" {
 
 variable "wait_for_capacity_timeout" {
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
+  type        = string
   default     = "10m"
 }
 
 variable "min_elb_capacity" {
   description = "Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes"
+  type        = number
   default     = 0
 }
 
 variable "wait_for_elb_capacity" {
   description = "Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over min_elb_capacity behavior."
-  default     = false
+  type        = number
+  default     = null
 }
 
 variable "protect_from_scale_in" {
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events."
+  type        = bool
   default     = false
 }
 
 variable "service_linked_role_arn" {
   description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
+  type        = string
   default     = ""
 }
 
 variable "on_demand_base_capacity" {
   description = "Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances"
+  type        = number
   default     = 0
 }
 
 variable "on_demand_percentage_above_base_capacity" {
   description = "Percentage split between on-demand and Spot instances above the base on-demand capacity."
+  type        = number
   default     = 100
+}
+
+variable "spot_allocation_strategy" {
+  description = "How to allocate capacity across the Spot pools. Valid values: 'lowest-price', 'capacity-optimized'."
+  type        = string
+  default     = "capacity-optimized"
 }
 
 variable "spot_instance_pools" {
   description = "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Diversifies your Spot capacity across multiple instance types to find the best pricing."
-  default     = 1
+  type        = number
+  default     = 2
 }
 
 variable "spot_price" {
   description = "The price to use for reserving spot instances"
+  type        = string
   default     = ""
 }
+


### PR DESCRIPTION
Closes #2 

Breaking changes:
* `instance_types` parameter changes.
Previous: `instance_types = ["t2.micro", "t3.micro"]`
Now: `instance_types = [{instance_type = "t2.micro"}, {instance_type = "t3.micro"}]`
Rationale: to support instance weighting. Read the README on this variable.


Changes:
* Upgraded to 0.12 syntax, can be used with 0.12 and up
* Added `spot_allocation_strategy` variable. Changed default behaviour to aws recommendation `capacity-optimized` instead of terraform's default `lowest-price`.