### PR TITLE
Added support to refresh instance on ASG update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module "asg" {
 
   image_id        = "ami-ebd02392"
   security_groups = ["sg-12345678"]
-  
+
   block_device_mappings = [
     {
       # Root block device
@@ -91,7 +91,7 @@ module "asg" {
   max_size                  = 1
   desired_capacity          = 1
   wait_for_capacity_timeout = 0
-  
+
   ignore_desired_capacity_changes = true
 
   tags = [
@@ -111,7 +111,7 @@ module "asg" {
     extra_tag1 = "extra_value1"
     extra_tag2 = "extra_value2"
   }
-  
+
   instance_types = [
     {
       instance_type = "t2.micro",
@@ -252,6 +252,10 @@ No requirements.
 | vpc\_zone\_identifier | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `"10m"` | no |
 | wait\_for\_elb\_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over min\_elb\_capacity behavior. | `number` | `null` | no |
+| asg\_instance\_refresh\_strategy | The strategy to use for instance refresh. The only allowed value is `Rolling`. | `string` | `Rolling` | no |
+| asg\_instance\_refresh\_warmup | The number of seconds until a newly launched instance is configured and ready to use. | `number` | `300` | no |
+| asg\_instance\_refresh\_healthy\_percentage | The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `90` | no |
+| asg\_instance\_refresh\_additional\_triggers | Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy. | `list(string)` | <pre>[<br>  "tags"<br>]</pre> | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ No requirements.
 | asg\_instance\_refresh\_strategy | The strategy to use for instance refresh. The only allowed value is `Rolling`. | `string` | `null` | no |
 | asg\_instance\_refresh\_warmup | The number of seconds until a newly launched instance is configured and ready to use. | `number` | `null` | no |
 | asg\_instance\_refresh\_healthy\_percentage | The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `null` | no |
-| asg\_instance\_refresh\_additional\_triggers | Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy. | `list(string)` | <pre>[<br>  "tags"<br>]</pre> | no |
+| asg\_instance\_refresh\_additional\_triggers | Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy. | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ No requirements.
 | vpc\_zone\_identifier | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
 | wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `"10m"` | no |
 | wait\_for\_elb\_capacity | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over min\_elb\_capacity behavior. | `number` | `null` | no |
-| asg\_instance\_refresh\_strategy | The strategy to use for instance refresh. The only allowed value is `Rolling`. | `string` | `Rolling` | no |
-| asg\_instance\_refresh\_warmup | The number of seconds until a newly launched instance is configured and ready to use. | `number` | `300` | no |
-| asg\_instance\_refresh\_healthy\_percentage | The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `90` | no |
+| asg\_instance\_refresh\_strategy | The strategy to use for instance refresh. The only allowed value is `Rolling`. | `string` | `null` | no |
+| asg\_instance\_refresh\_warmup | The number of seconds until a newly launched instance is configured and ready to use. | `number` | `null` | no |
+| asg\_instance\_refresh\_healthy\_percentage | The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `null` | no |
 | asg\_instance\_refresh\_additional\_triggers | Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy. | `list(string)` | <pre>[<br>  "tags"<br>]</pre> | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,15 @@ resource "aws_autoscaling_group" "this" {
     local.tags_asg_format,
   )
 
+  instance_refresh {
+    strategy = var.asg_instance_refresh_strategy
+    preferences {
+      instance_warmup = var.asg_instance_refresh_warmup
+      min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+    }
+    triggers = var.asg_instance_refresh_additional_triggers
+  }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -241,6 +250,15 @@ resource "aws_autoscaling_group" "this_ignore_desired_capacity_changes" {
     var.tags,
     local.tags_asg_format,
   )
+
+  instance_refresh {
+    strategy = var.asg_instance_refresh_strategy
+    preferences {
+      instance_warmup = var.asg_instance_refresh_warmup
+      min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+    }
+    triggers = var.asg_instance_refresh_additional_triggers
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -147,13 +147,22 @@ resource "aws_autoscaling_group" "this" {
     local.tags_asg_format,
   )
 
-  instance_refresh {
-    strategy = var.asg_instance_refresh_strategy
-    preferences {
-      instance_warmup = var.asg_instance_refresh_warmup
-      min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+  dynamic "instance_refresh" {
+    for_each = var.asg_instance_refresh_strategy != null ? [1] : []
+
+    content {
+        strategy = var.asg_instance_refresh_strategy
+        triggers = var.asg_instance_refresh_additional_triggers
+
+        dynamic "preferences" {
+          for_each = var.asg_instance_refresh_warmup != null || var.asg_instance_refresh_healthy_percentage != null ? [1] : []
+
+          content {
+            instance_warmup = var.asg_instance_refresh_warmup
+            min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+          }
+        }
     }
-    triggers = var.asg_instance_refresh_additional_triggers
   }
 
   lifecycle {
@@ -251,13 +260,22 @@ resource "aws_autoscaling_group" "this_ignore_desired_capacity_changes" {
     local.tags_asg_format,
   )
 
-  instance_refresh {
-    strategy = var.asg_instance_refresh_strategy
-    preferences {
-      instance_warmup = var.asg_instance_refresh_warmup
-      min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+  dynamic "instance_refresh" {
+    for_each = var.asg_instance_refresh_strategy != null ? [1] : []
+
+    content {
+        strategy = var.asg_instance_refresh_strategy
+        triggers = var.asg_instance_refresh_additional_triggers
+
+        dynamic "preferences" {
+          for_each = var.asg_instance_refresh_warmup != null || var.asg_instance_refresh_healthy_percentage != null ? [1] : []
+
+          content {
+            instance_warmup = var.asg_instance_refresh_warmup
+            min_healthy_percentage = var.asg_instance_refresh_healthy_percentage
+          }
+        }
     }
-    triggers = var.asg_instance_refresh_additional_triggers
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -361,5 +361,5 @@ variable "asg_instance_refresh_healthy_percentage" {
 variable "asg_instance_refresh_additional_triggers" {
   description = "Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy."
   type        = list(string)
-  default     = ["tags"]
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -338,3 +338,28 @@ variable "capacity_rebalance" {
   type        = bool
   default     = null
 }
+
+# ASG instance refresh variables
+variable "asg_instance_refresh_strategy" {
+  description = "The strategy to use for instance refresh. The only allowed value is `Rolling`."
+  type        = string
+  default     = "Rolling"
+}
+
+variable "asg_instance_refresh_warmup" {
+  description = "The number of seconds until a newly launched instance is configured and ready to use."
+  type        = number
+  default     = 300
+}
+
+variable "asg_instance_refresh_healthy_percentage" {
+  description = "The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group."
+  type        = number
+  default     = 90
+}
+
+variable "asg_instance_refresh_additional_triggers" {
+  description = "Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy."
+  type        = list(string)
+  default     = ["tags"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -343,19 +343,19 @@ variable "capacity_rebalance" {
 variable "asg_instance_refresh_strategy" {
   description = "The strategy to use for instance refresh. The only allowed value is `Rolling`."
   type        = string
-  default     = "Rolling"
+  default     = null
 }
 
 variable "asg_instance_refresh_warmup" {
   description = "The number of seconds until a newly launched instance is configured and ready to use."
   type        = number
-  default     = 300
+  default     = null
 }
 
 variable "asg_instance_refresh_healthy_percentage" {
   description = "The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group."
   type        = number
-  default     = 90
+  default     = null
 }
 
 variable "asg_instance_refresh_additional_triggers" {


### PR DESCRIPTION
In this PR:

- Added support to ASG to refresh instance on update

more details could be found [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#instance_refresh)
