### PR TITLE
Add tags attribute to aws_launch_template resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ resource "aws_launch_template" "this" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = var.tags_as_map
 }
 
 ####################


### PR DESCRIPTION
Adding attribute for reporting. Attribute is available per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#tags