### PR TITLE
Update gha and remove set-output

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -111,6 +111,8 @@ jobs:
           popd
       - name: Install pre-commit dependency - tflint
         uses: terraform-linters/setup-tflint@v2
+        with:
+          tflint_version: v0.26.0
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,14 +15,16 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: Checkout
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
           - name: Install Python
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
+            with:
+              python-version: 3.x
           - name: Build matrix
             id: matrix
             run: |
               DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
-              echo "::set-output name=directories::$DIRS"
+              echo "directories=$DIRS" >> $GITHUB_OUTPUT
       outputs:
           directories: ${{ steps.matrix.outputs.directories }}
 
@@ -36,16 +38,18 @@ jobs:
             directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.1
+        uses: clowdhaus/terraform-min-max@v1.2.0
         with:
           directory: ${{ matrix.directory }}
       - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.minMax.outputs.minVersion }}
       - name: Install pre-commit dependencies
@@ -70,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.1
+        uses: clowdhaus/terraform-min-max@v1.2.0
     outputs:
       minVersion: ${{ steps.minMax.outputs.minVersion }}
       maxVersion: ${{ steps.minMax.outputs.maxVersion }}
@@ -90,19 +94,26 @@ jobs:
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - name: Install Terraform v${{ matrix.version }}
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.version }}
-      - name: Install pre-commit dependencies
+      - name: Install pre-commit dependency - terraform-docs
         run: |
-          pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12\..+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
+          TF_DOCS_VER="v0.12.1"
+          pushd /tmp
+            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/${TF_DOCS_VER}/terraform-docs-${TF_DOCS_VER}-$(uname | tr '[:upper:]' '[:lower:]')-amd64 && chmod +x ./terraform-docs && sudo mv ./terraform-docs /usr/bin/
+          popd
+      - name: Install pre-commit dependency - tflint
+        uses: terraform-linters/setup-tflint@v2
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: fregante/release-with-changelog@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create "$GITHUB_REF_NAME" --generate-notes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -20,7 +20,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict

--- a/examples/asg_elb/README.md
+++ b/examples/asg_elb/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_elb"></a> [elb](#module\_elb) | terraform-aws-modules/elb/aws |  |
+| <a name="module_elb"></a> [elb](#module\_elb) | terraform-aws-modules/elb/aws | ~> 2.0 |
 | <a name="module_example_asg"></a> [example\_asg](#module\_example\_asg) | ../../ |  |
 
 ## Resources

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -114,7 +114,7 @@ module "example_asg" {
 ######
 module "elb" {
   source = "terraform-aws-modules/elb/aws"
-  version = "~> 3.0"
+  version = "~> 2.0"
 
   name = "elb-example"
 

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -114,6 +114,7 @@ module "example_asg" {
 ######
 module "elb" {
   source = "terraform-aws-modules/elb/aws"
+  version = "~> 3.0"
 
   name = "elb-example"
 

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -113,7 +113,7 @@ module "example_asg" {
 # ELB
 ######
 module "elb" {
-  source = "terraform-aws-modules/elb/aws"
+  source  = "terraform-aws-modules/elb/aws"
   version = "~> 2.0"
 
   name = "elb-example"


### PR DESCRIPTION
Note:
- Action [fregante/release-with-changelog](https://github.com/fregante/release-with-changelog) is deprecated. Use github cli's command instead.
- Same as [terraform-aws-cloudwatch-dashboard](https://github.com/HENNGE/terraform-aws-cloudwatch-dashboard/pull/6#discussion_r1019984964), tflint is pinned to latest version at the time of last commit
- Pinned [terraform-aws-elb](https://github.com/terraform-aws-modules/terraform-aws-elb) to v2.0