### PR TITLE
Fix deprecated argument `tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -193,7 +193,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/asg_ec2/README.md
+++ b/examples/asg_ec2/README.md
@@ -21,8 +21,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -45,7 +45,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/asg_ec2/main.tf
+++ b/examples/asg_ec2/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -16,8 +15,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_security_group" "default" {
@@ -107,7 +109,7 @@ module "example" {
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
+  vpc_zone_identifier       = data.aws_subnets.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1

--- a/examples/asg_ec2/versions.tf
+++ b/examples/asg_ec2/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 4.0"
     }
 
     null = {

--- a/examples/asg_ec2_external_launch_template/README.md
+++ b/examples/asg_ec2_external_launch_template/README.md
@@ -21,8 +21,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -44,7 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/asg_ec2_external_launch_template/main.tf
+++ b/examples/asg_ec2_external_launch_template/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -16,8 +15,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_ami" "amazon_linux" {
@@ -68,7 +70,7 @@ module "example" {
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
+  vpc_zone_identifier       = data.aws_subnets.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1

--- a/examples/asg_ec2_external_launch_template/versions.tf
+++ b/examples/asg_ec2_external_launch_template/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 4.0"
     }
 
     null = {

--- a/examples/asg_elb/README.md
+++ b/examples/asg_elb/README.md
@@ -21,8 +21,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -45,7 +45,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -9,8 +9,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_security_group" "default" {
@@ -88,7 +91,7 @@ module "example_asg" {
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
+  vpc_zone_identifier       = data.aws_subnets.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1
@@ -118,7 +121,7 @@ module "elb" {
 
   name = "elb-example"
 
-  subnets         = data.aws_subnet_ids.all.ids
+  subnets         = data.aws_subnets.all.ids
   security_groups = [data.aws_security_group.default.id]
   internal        = false
 

--- a/examples/asg_elb/versions.tf
+++ b/examples/asg_elb/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 4.0"
     }
 
     null = {

--- a/examples/asg_inital_lifecycle_hook/README.md
+++ b/examples/asg_inital_lifecycle_hook/README.md
@@ -21,8 +21,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -44,7 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/asg_inital_lifecycle_hook/main.tf
+++ b/examples/asg_inital_lifecycle_hook/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -16,8 +15,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 data "aws_security_group" "default" {
@@ -109,7 +111,7 @@ EOF
 
   # Auto scaling group
   asg_name                  = "example-asg"
-  vpc_zone_identifier       = data.aws_subnet_ids.all.ids
+  vpc_zone_identifier       = data.aws_subnets.all.ids
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1

--- a/examples/asg_inital_lifecycle_hook/versions.tf
+++ b/examples/asg_inital_lifecycle_hook/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 4.0"
     }
 
     null = {

--- a/main.tf
+++ b/main.tf
@@ -135,17 +135,24 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
-  tags = concat(
-    [
-      {
-        key                 = "Name"
-        value               = var.name
-        propagate_at_launch = true
-      },
-    ],
-    var.tags,
-    local.tags_asg_format,
-  )
+  dynamic "tag" {
+    for_each = concat(
+      [
+        {
+          key                 = "Name"
+          value               = var.name
+          propagate_at_launch = true
+        },
+      ],
+      var.tags,
+      local.tags_asg_format,
+    )
+    content {
+      key                 = tag.value.key
+      propagate_at_launch = tag.value.propagate_at_launch
+      value               = tag.value.value
+    }
+  }
 
   dynamic "instance_refresh" {
     for_each = var.asg_instance_refresh_strategy != null ? [1] : []
@@ -248,17 +255,24 @@ resource "aws_autoscaling_group" "this_ignore_desired_capacity_changes" {
     }
   }
 
-  tags = concat(
-    [
-      {
-        key                 = "Name"
-        value               = var.name
-        propagate_at_launch = true
-      },
-    ],
-    var.tags,
-    local.tags_asg_format,
-  )
+  dynamic "tag" {
+    for_each = concat(
+      [
+        {
+          key                 = "Name"
+          value               = var.name
+          propagate_at_launch = true
+        },
+      ],
+      var.tags,
+      local.tags_asg_format,
+    )
+    content {
+      key                 = tag.value.key
+      propagate_at_launch = tag.value.propagate_at_launch
+      value               = tag.value.value
+    }
+  }
 
   dynamic "instance_refresh" {
     for_each = var.asg_instance_refresh_strategy != null ? [1] : []

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 4.0"
     }
 
     null = {


### PR DESCRIPTION
`tags` has long been deprecated.
Instead we should use `tag` and create it multiple times with dynamic block.